### PR TITLE
fix suggestion - range with wait group

### DIFF
--- a/10-Multithreading/4-Channels/4-Range-with-Wait-Group/main.go
+++ b/10-Multithreading/4-Channels/4-Range-with-Wait-Group/main.go
@@ -28,5 +28,4 @@ func publish(ch chan int) {
 	for i := 0; i < 10; i++ {
 		ch <- i
 	}
-	close(ch)
 }


### PR DESCRIPTION
Assistindo `a aula Range with WaitGroup, entendi que o `close(ch)` não é mais necessário pois o `wg.done()` se encarrega de sincronizar e finalizar o canal.
Espero estar certo.
Obrigado! 